### PR TITLE
CORE-8065: add a default way to force an internal-system-error to be …

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,10 @@
   :url "https://github.com/cyverse-de/iplant-clojure-commons"
   :license {:name "BSD"
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
-  :plugins [[test2junit "1.2.2"]]
+  :eastwood {:exclude-namespaces [:test-paths]
+             :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
+  :plugins [[jonase/eastwood "0.2.3"]
+            [test2junit "1.2.2"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clojure_commons/error_codes.clj
+++ b/src/clojure_commons/error_codes.clj
@@ -50,6 +50,7 @@
 (deferr ERR_REQUEST_BODY_TOO_LARGE)
 (deferr ERR_CONFLICTING_QUERY_PARAMETER_VALUES)
 (deferr ERR_SCHEMA_VALIDATION)
+(deferr ERR_SYSTEM)
 
 
 (def ^:private http-status-for

--- a/src/clojure_commons/exception.clj
+++ b/src/clojure_commons/exception.clj
@@ -137,6 +137,9 @@
 (def unavailable-handler
   (default-error-handler resp/gateway-timeout ec/ERR_UNAVAILABLE))
 
+(def internal-system-error-handler
+  (default-error-handler resp/internal-server-error ec/ERR_SYSTEM))
+
 (defn unchecked-handler
   [error error-type request]
   (let [error-obj (:object (get-throw-context error))]
@@ -214,6 +217,5 @@
     ::request-failed           request-failed-handler
     ::temporary-redirect       temporary-redirect-handler
     ::unavailable              unavailable-handler
+    ::internal-system-error    internal-system-error-handler
     ::ex/default               unchecked-handler}})
-
-

--- a/src/clojure_commons/exception_util.clj
+++ b/src/clojure_commons/exception_util.clj
@@ -31,3 +31,8 @@
   "Throws an error indicating that a resource could not be found."
   [reason & {:as ex-info}]
   (throw+ (assoc ex-info :type ::cx/not-found :error reason)))
+
+(defn internal-system-error
+  "Throws an error explicitly indicating that an internal system error occurred."
+  [reason & {:as ex-info}]
+  (throw+ (assoc ex-info :type ::cx/internal-system-error :error reason)))


### PR DESCRIPTION
…thrown

The purpose of this change was simply to create a convenience function. I also added `eastwood` as a plugin in order to make it easy to lint the code.
