### PR TITLE
CORE-2006: added a partial replacement for Clostache

### DIFF
--- a/src/clojure_commons/template.clj
+++ b/src/clojure_commons/template.clj
@@ -1,0 +1,7 @@
+(ns clojure-commons.template
+  (:require [clojure.string :as string]))
+
+(defn render
+  "Takes a format string and a map of interpolation values to substitute into the string."
+  [fmt m]
+  (string/replace fmt #"\{\{([^\}]+)\}\}" (fn [[orig k]] (get m (keyword k) orig))))

--- a/test/clojure_commons/template_test.clj
+++ b/test/clojure_commons/template_test.clj
@@ -1,0 +1,20 @@
+(ns clojure-commons.template-test
+  (:require [clojure-commons.template :refer [render]]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest test-render
+  (let [cases [{:desc     "base case"
+                :fmt      "This is a {{foo}} of the {{bar}}."
+                :vals     {:foo "test" :bar "Emergency Broadcast System"}
+                :expected "This is a test of the Emergency Broadcast System."}
+               {:desc     "empty format string"
+                :fmt      ""
+                :vals     {:another "test"}
+                :expected ""}
+               {:desc     "missing key"
+                :fmt      "This is a {{foo}} of the {{bar}}."
+                :vals     {:foo "test"}
+                :expected "This is a test of the {{bar}}."}]]
+    (doseq [{:keys [desc fmt vals expected]} cases]
+      (testing desc
+        (is (= expected (render fmt vals)))))))

--- a/test/clojure_commons/template_test.clj
+++ b/test/clojure_commons/template_test.clj
@@ -14,7 +14,11 @@
                {:desc     "missing key"
                 :fmt      "This is a {{foo}} of the {{bar}}."
                 :vals     {:foo "test"}
-                :expected "This is a test of the {{bar}}."}]]
+                :expected "This is a test of the {{bar}}."}
+               {:desc     "empty template string"
+                :fmt      "This is a {{foo}} of the {{}}."
+                :vals     {:foo "test"}
+                :expected "This is a test of the {{}}."}]]
     (doseq [{:keys [desc fmt vals expected]} cases]
       (testing desc
         (is (= expected (render fmt vals)))))))


### PR DESCRIPTION
This satisfies all of the uses of Clostache that I've found so far. Clostache appears to be unmaintained at the moment, so this is a way for us to ensure that we can keep dependencies up to date without having to maintain a complete fork of Clostache. If we find any cases that this implementation can't support, we can reconsider forking Clostache then.