### PR TITLE
CORE-2021 Fix class cast exceptions in template/render

### DIFF
--- a/src/clojure_commons/template.clj
+++ b/src/clojure_commons/template.clj
@@ -4,4 +4,4 @@
 (defn render
   "Takes a format string and a map of interpolation values to substitute into the string."
   [fmt m]
-  (string/replace fmt #"\{\{([^\}]+)\}\}" (fn [[orig k]] (get m (keyword k) orig))))
+  (string/replace fmt #"\{\{([^\}]+)\}\}" (fn [[orig k]] (str (get m (keyword k) orig)))))

--- a/test/clojure_commons/template_test.clj
+++ b/test/clojure_commons/template_test.clj
@@ -18,7 +18,11 @@
                {:desc     "empty template string"
                 :fmt      "This is a {{foo}} of the {{}}."
                 :vals     {:foo "test"}
-                :expected "This is a test of the {{}}."}]]
+                :expected "This is a test of the {{}}."}
+               {:desc     "number and UUID values"
+                :fmt      "This is test {{foo}} for UUID {{bar}}."
+                :vals     {:foo 5 :bar (parse-uuid "feedface-cafe-b0ba-feed-facedeadbeaf")}
+                :expected "This is test 5 for UUID feedface-cafe-b0ba-feed-facedeadbeaf."}]]
     (doseq [{:keys [desc fmt vals expected]} cases]
       (testing desc
         (is (= expected (render fmt vals)))))))


### PR DESCRIPTION
This PR will fix exceptions when template values contain numbers or UUIDs, such as in the apps service sharing notification messages.